### PR TITLE
SwiftUI view depending on abstract

### DIFF
--- a/SUI Koober.xcodeproj/project.pbxproj
+++ b/SUI Koober.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		60C329EB22BDDDBA007A1C71 /* SignInViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C329EA22BDDDBA007A1C71 /* SignInViewModel.swift */; };
 		9F35695322ADC12E007FA94C /* SignInUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F35695222ADC12E007FA94C /* SignInUseCase.swift */; };
 		9F86EE2922B1378600E36C64 /* KooberDependencyContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F86EE2822B1378600E36C64 /* KooberDependencyContainer.swift */; };
 		9F9F397822AC7C0E004D2B76 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9F397722AC7C0E004D2B76 /* AppDelegate.swift */; };
@@ -29,6 +30,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		60C329EA22BDDDBA007A1C71 /* SignInViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewModel.swift; sourceTree = "<group>"; };
 		9F35695222ADC12E007FA94C /* SignInUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInUseCase.swift; sourceTree = "<group>"; };
 		9F86EE2822B1378600E36C64 /* KooberDependencyContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KooberDependencyContainer.swift; sourceTree = "<group>"; };
 		9F9F397422AC7C0E004D2B76 /* SUI Koober.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SUI Koober.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -134,6 +136,7 @@
 				9F9F399D22AC88B1004D2B76 /* OnboardView.swift */,
 				9F9F398F22AC7D4D004D2B76 /* WelcomeView.swift */,
 				9F9F399122AC8203004D2B76 /* SignInView.swift */,
+				60C329EA22BDDDBA007A1C71 /* SignInViewModel.swift */,
 				9F9F399322AC8219004D2B76 /* SignUpView.swift */,
 			);
 			path = Onboard;
@@ -258,6 +261,7 @@
 				9F9F399C22AC86E2004D2B76 /* RunningView.swift in Sources */,
 				9F9F39A022ADA25E004D2B76 /* Koober.swift in Sources */,
 				9F9F399822AC85C5004D2B76 /* NewRideView.swift in Sources */,
+				60C329EB22BDDDBA007A1C71 /* SignInViewModel.swift in Sources */,
 				9F35695322ADC12E007FA94C /* SignInUseCase.swift in Sources */,
 				9FE8C31222ADBF10000F4F50 /* UserAuthenticationRemoteAPI.swift in Sources */,
 				9F9F399422AC8219004D2B76 /* SignUpView.swift in Sources */,

--- a/SUI Koober/App/Running/Onboard/SignInView.swift
+++ b/SUI Koober/App/Running/Onboard/SignInView.swift
@@ -3,26 +3,24 @@
 import SwiftUI
 
 struct SignInView : View {
-  let startSignInUseCase: (String, String) -> Void
   
-  @State private var username: String = ""
-  @State private var password: String = ""
+  let viewModel: SignInViewModelProtocol
   
   var body: some View {
     VStack {
-      FormField($username) {
+      FormField(viewModel.email) {
         Text("Username")
           .color(.white)
           .frame(width: 80)
           .padding()
       }
-      FormField($password, secure: true) {
+      FormField(viewModel.password, secure: true) {
         Text("Password")
           .color(.white)
           .frame(width: 80)
           .padding()
       }
-      Button(action: signIn) {
+      Button(action: viewModel.signIn) {
         Text("Sign In")
       }
       .accentColor(.white)
@@ -35,19 +33,15 @@ struct SignInView : View {
     .edgesIgnoringSafeArea(.bottom)
     .navigationBarTitle(Text("Sign In"))
   }
-  
-  func signIn() {
-    startSignInUseCase(username, password)
-  }
 }
 
 #if DEBUG
 struct SignInView_Previews : PreviewProvider {
   static var previews: some View {
-    NavigationView{
-      SignInView(startSignInUseCase: { username, password in
+    NavigationView {
+      SignInView(viewModel: SignInViewModel(startSignInUseCase: { username, password in
         print("Start sign in use case. \(username):\(password)")
-      })
+      }))
     }
   }
 }

--- a/SUI Koober/App/Running/Onboard/SignInViewModel.swift
+++ b/SUI Koober/App/Running/Onboard/SignInViewModel.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+protocol SignInViewModelProtocol {
+  
+  var email: Binding<String> { get }
+  var password: Binding<String> { get }
+  
+  func signIn()
+}
+
+
+final class SignInViewModel {
+  
+  private var _email = ""
+  private var _password = ""
+  
+  private let startSignInUseCase: (String, String) -> Void
+  
+  init(startSignInUseCase: @escaping (String, String) -> Void) {
+    self.startSignInUseCase = startSignInUseCase
+  }
+}
+
+extension SignInViewModel: SignInViewModelProtocol {
+  
+  var email: Binding<String> {
+    return .init(getValue: { self._email }, setValue: { self._email = $0 })
+  }
+  
+  var password: Binding<String> {
+    return .init(getValue: { self._password }, setValue: { self._password = $0 })
+  }
+  
+  func signIn() {
+    startSignInUseCase(_email, _password)
+  }
+}

--- a/SUI Koober/App/Running/Onboard/WelcomeView.swift
+++ b/SUI Koober/App/Running/Onboard/WelcomeView.swift
@@ -46,7 +46,7 @@ private struct SignInSignUpButtons : View {
   var body: some View {
     HStack {
       
-      NavigationButton(destination: SignInView(startSignInUseCase: koober.startSignInUseCase)) {
+      NavigationButton(destination: SignInView(viewModel: SignInViewModel(startSignInUseCase: koober.startSignInUseCase))) {
         Text("Sign In")
       }
       .accentColor(.white)


### PR DESCRIPTION
## Checklist

- [x] I've looked at the [contribution guidelines](CONTRIBUTING.md).

## Description
<!-- Detail the changes that you've made. For non-trivial changes, please explain what you're trying to do so others can read and learn from your changes -->

Been doing some experimentation on having SwiftUI views to depend on an abstract model. The model could then be injected and have mock representations for testing.

### Pros to this approach
* Ability to control surface area of `Bindable` properties
* Extracts some responsibility away from SwiftUI view
* SwiftUI view can now depend on an abstract type rather than concrete

### Cons
* `Binding<Value>` requires a backing property; You will need a separate variable to hold the state of the `Binding`:

```
var _email = ""
var email: Binding<String> { return .init(getValue: {  self._email }, setValue: { self._email = $0 }) }
```
* Unable to harness the power of property wrappers 
* Compiler complains if you try to use a struct type that exposes a `Binding` (binding requires a way to mutate some backing property, which violates the value semantics of the struct)

Asking for opinions on whether this is a good idea or not. Relevant thread with some opinions from Joe Groff: https://forums.swift.org/t/state-messing-with-initializer-flow/25276/8